### PR TITLE
install libxml from http instead of ftp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ftp://xmlsoft.org/libxml2/python/libxml2-python-2.6.15.tar.gz
+http://xmlsoft.org/sources/python/libxml2-python-2.6.21.tar.gz


### PR DESCRIPTION
because pip has issues: https://github.com/pypa/pip/issues/1693

fixes #12
