### PR TITLE
Updates dependency on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ or you may put `ThreeScalePY.py` inside the same directory as your program.
 
 ## Dependencies
 
-**libxml2** is required, if you are unable to install (as in Google AppEngine), please use the `ElementTree` branch.
+**lxml** is required.
 
-You can get the `libxml2` bindings for Python from: ftp://xmlsoft.org/libxml2/python/libxml2-python-2.6.21.tar.gz  
+You can get the `lxml` bindings for Python from: https://github.com/lxml/lxml/releases
 
 The easiest way to install it is using pip:
 ```shell


### PR DESCRIPTION
libxml2 is no longer used. Similarly, the master branch now works on Google App Engine with this dependency update.